### PR TITLE
New features, refactoring and replacement of Flask by Quart

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+
+[*]
+# Unix-style newlines
+end_of_line = lf
+# Always end with an empty new line
+insert_final_newline = true
+# Set default charset to utf-8
+charset = utf-8
+# Indent with 2 spaces
+indent_style = space
+indent_size = 2
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 config.ini
+
+# ignore venv
+**/.venv
+
+# ignore python cache
+**/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:alpine
 WORKDIR /usr/src/app
 RUN apk update
-RUN apk add git rsync
+RUN apk add git rsync terraform
 RUN apk add docker
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/config.ini
+++ b/config.ini
@@ -2,6 +2,8 @@
 # ALLOWED_IP_RANGE = 192.168.0.0/24
 # DEBUG = true
 # GIT_SSL_NO_VERIFY = true
+# GIT_SSH_NO_VERIFY = true
+# GIT_PROTOCOL = http
 # LISTEN_PORT = 1706
 
 [rsync]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-Flask>=2.1.0
-waitress>=2.1.0
+quart==0.18.3

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -1,0 +1,123 @@
+import logging
+from ipaddress import ip_address, ip_network
+from os import access, environ, X_OK
+from shutil import which
+
+from quart import Quart, request, jsonify
+
+
+def create_app(config):
+    print("Tea Runner")
+    # Configure loglevel
+    if config.getboolean("runner", "DEBUG", fallback="False") == True:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
+        logging.info("Debug logging is on")
+    else:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
+
+    app = Quart(__name__)
+
+    # Configure Quart
+    app.runner_config = config
+    app.git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
+
+    # Check presence of external programs
+    app.docker = which("docker")
+    try:
+        access(app.docker, X_OK)
+    except:
+        logging.error("docker binary not found or not executable")
+        exit(1)
+
+    app.git = which("git")
+    try:
+        access(app.git, X_OK)
+    except:
+        logging.error("git binary not found or not executable")
+        exit(1)
+
+    app.rsync = which("rsync")
+    try:
+        access(app.rsync, X_OK)
+    except:
+        logging.error("rsync binary not found or not executable")
+        exit(1)
+
+    app.tf_bin = which("terraform")
+    try:
+        access(app.tf_bin, X_OK)
+    except:
+        logging.error("terraform binary not found or not executable")
+        exit(1)
+
+    # Set environment variables
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ["GIT_SSL_NO_VERIFY"] = "true"
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ[
+            "GIT_SSH_COMMAND"
+        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
+
+    # Log some informations
+    logging.info("git protocol is " + app.git_protocol)
+    logging.info(
+        "Limiting requests to: "
+        + app.runner_config.get("runner", "ALLOWED_IP_RANGE", fallback="<any>")
+    )
+
+    @app.before_request
+    async def check_authorized():
+        """
+        Only respond to requests from ALLOWED_IP_RANGE if it's configured in config.ini
+        """
+        if app.runner_config.has_option("runner", "ALLOWED_IP_RANGE"):
+            allowed_ip_range = ip_network(
+                app.runner_config["runner"]["ALLOWED_IP_RANGE"]
+            )
+            requesting_ip = ip_address(request.remote_addr)
+            if requesting_ip not in allowed_ip_range:
+                logging.info(
+                    "Dropping request from unauthorized host " + request.remote_addr
+                )
+                return jsonify(status="forbidden"), 403
+            else:
+                logging.info("Request from " + request.remote_addr)
+
+    @app.before_request
+    async def check_media_type():
+        """
+        Only respond requests with Content-Type header of application/json
+        """
+        if (
+            not request.headers.get("Content-Type")
+            .lower()
+            .startswith("application/json")
+        ):
+            logging.error(
+                '"Content-Type: application/json" header missing from request made by '
+                + request.remote_addr
+            )
+            return jsonify(status="unsupported media type"), 415
+
+    @app.route("/test", methods=["POST"])
+    async def test():
+        logging.debug("Content-Type: " + request.headers.get("Content-Type"))
+        logging.debug(await request.get_json(force=True))
+        return jsonify(status="success", sender=request.remote_addr)
+
+    # Register Blueprints
+    from runner.docker import docker as docker_bp
+    from runner.rsync import rsync as rsync_bp
+    from runner.terraform import terraform as terraform_bp
+
+    app.register_blueprint(docker_bp, url_prefix="/docker")
+    app.register_blueprint(rsync_bp)
+    app.register_blueprint(terraform_bp, url_prefix="/terraform")
+
+    return app

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -3,7 +3,7 @@ from os import chdir, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
-from flask import Blueprint, current_app, jsonify, request
+from quart import Blueprint, current_app, jsonify, request
 
 import runner.utils
 
@@ -11,8 +11,8 @@ docker = Blueprint("docker", __name__)
 
 
 @docker.route("/build", methods=["POST"])
-def docker_build():
-    body = request.get_json()
+async def docker_build():
+    body = await request.get_json()
 
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -1,0 +1,36 @@
+import logging
+from os import chdir, path
+from subprocess import run, DEVNULL
+from tempfile import TemporaryDirectory
+
+from flask import Blueprint, current_app, jsonify, request
+
+import runner.utils
+
+docker = Blueprint("docker", __name__)
+
+
+@docker.route("/build", methods=["POST"])
+def docker_build():
+    body = request.get_json()
+
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("docker build")
+            chdir(temp_dir)
+            result = run(
+                [current_app.docker, "build", "-t", body["repository"]["name"], "."],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="docker build failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir, getcwd, path
+from os import chdir, getcwd
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir, path
+from os import chdir, getcwd, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
@@ -15,6 +15,7 @@ async def docker_build():
     body = await request.get_json()
 
     with TemporaryDirectory() as temp_dir:
+        current_dir = getcwd()
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if current_app.git_protocol == "http"
@@ -28,6 +29,7 @@ async def docker_build():
                 stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
                 stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
+            chdir(current_dir)
             if result.returncode != 0:
                 return jsonify(status="docker build failed"), 500
         else:

--- a/runner/rsync.py
+++ b/runner/rsync.py
@@ -3,7 +3,7 @@ from os import chdir, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
-from flask import Blueprint, current_app, jsonify, request
+from quart import Blueprint, current_app, jsonify, request
 from werkzeug import utils
 
 import runner.utils
@@ -12,8 +12,8 @@ rsync = Blueprint("rsync", __name__)
 
 
 @rsync.route("/rsync", methods=["POST"])
-def route_rsync():
-    body = request.get_json()
+async def route_rsync():
+    body = await request.get_json()
     dest = request.args.get("dest") or body["repository"]["name"]
     rsync_root = current_app.runner_config.get("rsync", "RSYNC_ROOT", fallback="")
     if rsync_root:

--- a/runner/rsync.py
+++ b/runner/rsync.py
@@ -1,0 +1,58 @@
+import logging
+from os import chdir, path
+from subprocess import run, DEVNULL
+from tempfile import TemporaryDirectory
+
+from flask import Blueprint, current_app, jsonify, request
+from werkzeug import utils
+
+import runner.utils
+
+rsync = Blueprint("rsync", __name__)
+
+
+@rsync.route("/rsync", methods=["POST"])
+def route_rsync():
+    body = request.get_json()
+    dest = request.args.get("dest") or body["repository"]["name"]
+    rsync_root = current_app.runner_config.get("rsync", "RSYNC_ROOT", fallback="")
+    if rsync_root:
+        dest = path.join(rsync_root, utils.secure_filename(dest))
+        logging.debug("rsync dest path updated to " + dest)
+
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("rsync " + body["repository"]["name"] + " to " + dest)
+            chdir(temp_dir)
+            if current_app.runner_config.get("rsync", "DELETE", fallback=""):
+                result = run(
+                    [
+                        current_app.rsync,
+                        "-r",
+                        "--exclude=.git",
+                        "--delete-during"
+                        if current_app.runner_config.get("rsync", "DELETE", fallback="")
+                        else "",
+                        ".",
+                        dest,
+                    ],
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+                )
+            else:
+                result = run(
+                    [current_app.rsync, "-r", "--exclude=.git", ".", dest],
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+                )
+            if result.returncode != 0:
+                return jsonify(status="rsync failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")

--- a/runner/rsync.py
+++ b/runner/rsync.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir, path
+from os import chdir, getcwd, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
@@ -21,6 +21,7 @@ async def route_rsync():
         logging.debug("rsync dest path updated to " + dest)
 
     with TemporaryDirectory() as temp_dir:
+        current_dir = getcwd()
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if current_app.git_protocol == "http"
@@ -50,6 +51,7 @@ async def route_rsync():
                     stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
                     stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
                 )
+            chdir(current_dir)
             if result.returncode != 0:
                 return jsonify(status="rsync failed"), 500
         else:

--- a/runner/terraform.py
+++ b/runner/terraform.py
@@ -1,0 +1,73 @@
+import logging
+from os import chdir
+from subprocess import run, DEVNULL
+from tempfile import TemporaryDirectory
+
+from flask import Blueprint, current_app, jsonify, request
+
+import runner.utils
+
+terraform = Blueprint("terraform", __name__)
+
+
+@terraform.route("/plan", methods=["POST"])
+def terraform_plan():
+    body = request.get_json()
+
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("terraform init")
+            chdir(temp_dir)
+            result = run(
+                [current_app.tf_bin, "init", "-no-color"],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform init failed"), 500
+            result = run(
+                [current_app.tf_bin, "plan", "-no-color"], stdout=None, stderr=None
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform plan failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")
+
+
+@terraform.route("/apply", methods=["POST"])
+def terraform_apply():
+    body = request.get_json()
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("terraform init")
+            chdir(temp_dir)
+            result = run(
+                [current_app.tf_bin, "init", "-no-color"],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform init failed"), 500
+            result = run(
+                [current_app.tf_bin, "apply", "-auto-approve", "-no-color"],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform apply failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")

--- a/runner/terraform.py
+++ b/runner/terraform.py
@@ -3,7 +3,7 @@ from os import chdir
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
-from flask import Blueprint, current_app, jsonify, request
+from quart import Blueprint, current_app, jsonify, request
 
 import runner.utils
 
@@ -11,8 +11,8 @@ terraform = Blueprint("terraform", __name__)
 
 
 @terraform.route("/plan", methods=["POST"])
-def terraform_plan():
-    body = request.get_json()
+async def terraform_plan():
+    body = await request.get_json()
 
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(

--- a/runner/utils.py
+++ b/runner/utils.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir
+from os import chdir, getcwd
 from subprocess import run, DEVNULL
 
 from quart import current_app
@@ -18,10 +18,12 @@ def git_clone(src_url, dest_dir):
     """
 
     logging.info("git clone " + src_url)
+    current_dir = getcwd()
     chdir(dest_dir)
     clone_result = run(
         [current_app.git, "clone", src_url, "."],
         stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
         stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
     )
+    chdir(current_dir)
     return clone_result.returncode == 0

--- a/runner/utils.py
+++ b/runner/utils.py
@@ -2,7 +2,7 @@ import logging
 from os import chdir
 from subprocess import run, DEVNULL
 
-from flask import current_app
+from quart import current_app
 
 
 def git_clone(src_url, dest_dir):

--- a/runner/utils.py
+++ b/runner/utils.py
@@ -1,0 +1,27 @@
+import logging
+from os import chdir
+from subprocess import run, DEVNULL
+
+from flask import current_app
+
+
+def git_clone(src_url, dest_dir):
+    """
+    Clone a remote git repository into a local directory.
+
+    Args:
+        src_url (string): Url used to clone the repo.
+        dest_dir (string): Path to the local directory.
+
+    Returns:
+       (boolean): True if command returns success.
+    """
+
+    logging.info("git clone " + src_url)
+    chdir(dest_dir)
+    clone_result = run(
+        [current_app.git, "clone", src_url, "."],
+        stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+        stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+    )
+    return clone_result.returncode == 0

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -60,13 +60,7 @@ def git_clone(src_url, dest_dir):
     """
 
     logging.info("git clone " + src_url)
-    if app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False") == True:
-        environ["GIT_SSL_NO_VERIFY"] = "true"
     chdir(dest_dir)
-    if app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False") == True:
-        environ[
-            "GIT_SSH_COMMAND"
-        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
     clone_result = run(
         [app.git, "clone", src_url, "."],
         stdout=None if args.debug else DEVNULL,
@@ -295,6 +289,19 @@ if __name__ == "__main__":
     except:
         logging.error("terraform binary not found or not executable")
         exit(1)
+
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ["GIT_SSL_NO_VERIFY"] = "true"
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ[
+            "GIT_SSH_COMMAND"
+        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
 
     serve(
         app,

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -63,8 +63,8 @@ def git_clone(src_url, dest_dir):
     chdir(dest_dir)
     clone_result = run(
         [app.git, "clone", src_url, "."],
-        stdout=None if args.debug else DEVNULL,
-        stderr=None if args.debug else DEVNULL,
+        stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+        stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
     )
     return clone_result.returncode == 0
 
@@ -139,14 +139,14 @@ def rsync():
                         ".",
                         dest,
                     ],
-                    stdout=None if args.debug else DEVNULL,
-                    stderr=None if args.debug else DEVNULL,
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
                 )
             else:
                 result = run(
                     [app.rsync, "-r", "--exclude=.git", ".", dest],
-                    stdout=None if args.debug else DEVNULL,
-                    stderr=None if args.debug else DEVNULL,
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
                 )
             if result.returncode != 0:
                 return jsonify(status="rsync failed"), 500
@@ -171,8 +171,8 @@ def docker_build():
             chdir(temp_dir)
             result = run(
                 [app.docker, "build", "-t", body["repository"]["name"], "."],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="docker build failed"), 500
@@ -197,8 +197,8 @@ def terraform_plan():
             chdir(temp_dir)
             result = run(
                 [app.tf_bin, "init", "-no-color"],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="terraform init failed"), 500
@@ -225,15 +225,15 @@ def terraform_apply():
             chdir(temp_dir)
             result = run(
                 [app.tf_bin, "init", "-no-color"],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="terraform init failed"), 500
             result = run(
                 [app.tf_bin, "apply", "-auto-approve", "-no-color"],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="terraform apply failed"), 500

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -23,18 +23,18 @@ Configuration file (config.ini) options:
     # TCP port number used for incoming requests. Defaults to 1706.
 """
 
+import logging
+from argparse import ArgumentParser
+from configparser import ConfigParser
 from ipaddress import ip_address, ip_network
-from os import path
+from os import  access, chdir, environ, path, X_OK
 from subprocess import run, DEVNULL
 from sys import exit
-from os import access, X_OK, chdir, environ, path
 from tempfile import TemporaryDirectory
+
+from flask import Flask, request, jsonify
 from waitress import serve
 from werkzeug import utils
-from flask import Flask, request, jsonify
-from configparser import ConfigParser
-from argparse import ArgumentParser
-import logging
 
 GIT_BIN = "/usr/bin/git"
 RSYNC_BIN = "/usr/bin/rsync"

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -37,6 +37,8 @@ from flask import Flask, request, jsonify
 from waitress import serve
 from werkzeug import utils
 
+import runner.utils
+
 print("Tea Runner")
 
 # Debug is a command-line option, but most configuration comes from config.ini
@@ -45,28 +47,6 @@ arg_parser.add_argument(
     "-d", "--debug", action="store_true", help="display debugging output while running"
 )
 args = arg_parser.parse_args()
-
-
-def git_clone(src_url, dest_dir):
-    """
-    Clone a remote git repository into a local directory.
-
-    Args:
-        src_url (string): Url used to clone the repo.
-        dest_dir (string): Path to the local directory.
-
-    Returns:
-       (boolean): True if command returns success.
-    """
-
-    logging.info("git clone " + src_url)
-    chdir(dest_dir)
-    clone_result = run(
-        [app.git, "clone", src_url, "."],
-        stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
-        stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
-    )
-    return clone_result.returncode == 0
 
 
 app = Flask(__name__)
@@ -119,7 +99,7 @@ def rsync():
         logging.debug("rsync dest path updated to " + dest)
 
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
@@ -161,7 +141,7 @@ def docker_build():
     body = request.get_json()
 
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
@@ -187,7 +167,7 @@ def terraform_plan():
     body = request.get_json()
 
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
@@ -215,7 +195,7 @@ def terraform_plan():
 def terraform_apply():
     body = request.get_json()
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -76,14 +76,13 @@ if not access(DOCKER_BIN, X_OK):
     exit(1)
 
 
-def git_clone(src_url, dest_dir, protocol):
+def git_clone(src_url, dest_dir):
     """
     Clone a remote git repository into a local directory.
 
     Args:
         src_url (string): Url used to clone the repo.
         dest_dir (string): Path to the local directory.
-        protocol (string): Protocol to use to clone the repo.
 
     Returns:
        (boolean): True if command returns success.
@@ -160,7 +159,6 @@ def rsync():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("rsync " + body["repository"]["name"] + " to " + dest)
             chdir(temp_dir)
@@ -203,7 +201,6 @@ def docker_build():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("docker build")
             chdir(temp_dir)
@@ -230,7 +227,6 @@ def terraform_plan():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("terraform init")
             chdir(temp_dir)
@@ -259,7 +255,6 @@ def terraform_apply():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("terraform init")
             chdir(temp_dir)

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -27,7 +27,7 @@ import logging
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from ipaddress import ip_address, ip_network
-from os import  access, chdir, environ, path, X_OK
+from os import access, chdir, environ, path, X_OK
 from subprocess import run, DEVNULL
 from sys import exit
 from tempfile import TemporaryDirectory

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -28,6 +28,7 @@ from argparse import ArgumentParser
 from configparser import ConfigParser
 from ipaddress import ip_address, ip_network
 from os import access, chdir, environ, path, X_OK
+from shutil import which
 from subprocess import run, DEVNULL
 from sys import exit
 from tempfile import TemporaryDirectory
@@ -36,10 +37,10 @@ from flask import Flask, request, jsonify
 from waitress import serve
 from werkzeug import utils
 
-GIT_BIN = "/usr/bin/git"
-RSYNC_BIN = "/usr/bin/rsync"
-DOCKER_BIN = "/usr/bin/docker"
-TF_BIN = "/usr/bin/terraform"
+GIT_BIN = which("git")
+RSYNC_BIN = which("rsync")
+DOCKER_BIN = which("docker")
+TF_BIN = which("terraform")
 
 print("Tea Runner")
 
@@ -65,14 +66,25 @@ else:
 git_protocol = config.get("runner", "GIT_PROTOCOL", fallback="http")
 logging.info("git protocol is " + git_protocol)
 
-if not access(GIT_BIN, X_OK):
+try:
+    access(GIT_BIN, X_OK)
+except:
     logging.error("git binary not found or not executable")
     exit(1)
-if not access(RSYNC_BIN, X_OK):
+try:
+    access(RSYNC_BIN, X_OK)
+except:
     logging.error("rsync binary not found or not executable")
     exit(1)
-if not access(DOCKER_BIN, X_OK):
+try:
+    access(DOCKER_BIN, X_OK)
+except:
     logging.error("docker binary not found or not executable")
+    exit(1)
+try:
+    access(TF_BIN, X_OK)
+except:
+    logging.error("terraform binary not found or not executable")
     exit(1)
 
 

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -23,19 +23,13 @@ Configuration file (config.ini) options:
     # TCP port number used for incoming requests. Defaults to 1706.
 """
 
-import logging
+import asyncio
 from argparse import ArgumentParser
 from configparser import ConfigParser
-from ipaddress import ip_address, ip_network
-from os import access, environ, X_OK
-from shutil import which
-from sys import exit
 
-from quart import Quart, request, jsonify
+from hypercorn.asyncio import Config, serve
 
-import runner.utils
-
-print("Tea Runner")
+import runner
 
 # Debug is a command-line option, but most configuration comes from config.ini
 arg_parser = ArgumentParser()
@@ -44,118 +38,18 @@ arg_parser.add_argument(
 )
 args = arg_parser.parse_args()
 
+quart_config = ConfigParser()
+quart_config.read("config.ini")
+hypercorn_config = Config()
 
-app = Quart(__name__)
+hypercorn_config.bind = (
+    quart_config.get("runner", "LISTEN_IP", fallback="0.0.0.0")
+    + ":"
+    + str(quart_config.getint("runner", "LISTEN_PORT", fallback=1706))
+)
 
+if args.debug:
+    quart_config.set("runner", "DEBUG", "true")
+    hypercorn_config.loglevel = "debug"
 
-@app.before_request
-async def check_authorized():
-    """
-    Only respond to requests from ALLOWED_IP_RANGE if it's configured in config.ini
-    """
-    if app.runner_config.has_option("runner", "ALLOWED_IP_RANGE"):
-        allowed_ip_range = ip_network(app.runner_config["runner"]["ALLOWED_IP_RANGE"])
-        requesting_ip = ip_address(request.remote_addr)
-        if requesting_ip not in allowed_ip_range:
-            logging.info(
-                "Dropping request from unauthorized host " + request.remote_addr
-            )
-            return jsonify(status="forbidden"), 403
-        else:
-            logging.info("Request from " + request.remote_addr)
-
-
-@app.before_request
-async def check_media_type():
-    """
-    Only respond requests with Content-Type header of application/json
-    """
-    if not request.headers.get("Content-Type").lower().startswith("application/json"):
-        logging.error(
-            '"Content-Type: application/json" header missing from request made by '
-            + request.remote_addr
-        )
-        return jsonify(status="unsupported media type"), 415
-
-
-@app.route("/test", methods=["POST"])
-async def test():
-    logging.debug("Content-Type: " + request.headers.get("Content-Type"))
-    logging.debug(await request.get_json(force=True))
-    return jsonify(status="success", sender=request.remote_addr)
-
-
-if __name__ == "__main__":
-    app.runner_config = ConfigParser()
-    app.runner_config.read("config.ini")
-
-    if args.debug:
-        app.runner_config.set("runner", "DEBUG", "true")
-
-    if app.runner_config.getboolean("runner", "DEBUG", fallback="False") == True:
-        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
-        logging.info("Debug logging is on")
-    else:
-        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
-
-    app.git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
-    logging.info("git protocol is " + app.git_protocol)
-
-    logging.info(
-        "Limiting requests to: "
-        + app.runner_config.get("runner", "ALLOWED_IP_RANGE", fallback="<any>")
-    )
-
-    app.git = which("git")
-    app.rsync = which("rsync")
-    app.docker = which("docker")
-    app.tf_bin = which("terraform")
-
-    try:
-        access(app.git, X_OK)
-    except:
-        logging.error("git binary not found or not executable")
-        exit(1)
-    try:
-        access(app.rsync, X_OK)
-    except:
-        logging.error("rsync binary not found or not executable")
-        exit(1)
-    try:
-        access(app.docker, X_OK)
-    except:
-        logging.error("docker binary not found or not executable")
-        exit(1)
-    try:
-        access(app.tf_bin, X_OK)
-    except:
-        logging.error("terraform binary not found or not executable")
-        exit(1)
-
-    if (
-        app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False")
-        == True
-    ):
-        environ["GIT_SSL_NO_VERIFY"] = "true"
-    if (
-        app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False")
-        == True
-    ):
-        environ[
-            "GIT_SSH_COMMAND"
-        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
-
-    from runner.docker import docker as docker_bp
-    from runner.rsync import rsync as rsync_bp
-    from runner.terraform import terraform as terraform_bp
-
-    app.register_blueprint(docker_bp, url_prefix="/docker")
-    app.register_blueprint(rsync_bp)
-    app.register_blueprint(terraform_bp, url_prefix="/terraform")
-
-
-    app.run(
-        host=app.runner_config.get("runner", "LISTEN_IP", fallback="0.0.0.0"),
-        port=app.runner_config.getint("runner", "LISTEN_PORT", fallback=1706),
-        debug=logging.root.level,
-    )
+asyncio.run(serve(runner.create_app(quart_config), hypercorn_config))

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -101,7 +101,7 @@ def rsync():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -143,7 +143,7 @@ def docker_build():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -169,7 +169,7 @@ def terraform_plan():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -197,7 +197,7 @@ def terraform_apply():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -236,8 +236,8 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
-    git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
-    logging.info("git protocol is " + git_protocol)
+    app.git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
+    logging.info("git protocol is " + app.git_protocol)
 
     logging.info(
         "Limiting requests to: "


### PR DESCRIPTION
This PR contains several changes:

### New features:

* Two new routes were added to support [Terraform](https://terraform.io) operations. Terraform need to be installed on the running host. **Beware that terraform operations may take some time.** I advise increasing the time out duration on gitea if you plan to use it. This is done by editing the value of the `DELIVER_TIMEOUT` parameter in the [`webhook`](https://docs.gitea.io/en-us/config-cheat-sheet/#webhook-webhook) section.
* Allow the use of SSH instead of HTTP(s) when cloning repositories. The default setting remains HTTP(s).

### Refactoring

* In order to improve readability of code, and to ease the addition of new routes, the application is now split in several files.
* Inclusion of `__pycache__` and `.venv` directories to the list of files ignored by git.
* Creation of a `.editorconfig` file to helps maintaining consistent coding styles (see [editconfig.org](https://editorconfig.org/) for more information).
* The main application is now defined as a module (see the `runner` directory, however the starting script (tea-runner.py) can be use all the same.

### Breaking changes:

In order to use background tasks in the future, tea-runner is now using:
* [Quart](https://quart.palletsprojects.com/) instead of [Flask](https://flask.palletsprojects.com/).
* [Hypercorn](https://hypercorn.readthedocs.io/) instead of [Waitress](https://docs.pylonsproject.org/projects/waitress/).

### Code style

* Imports were re-ordered, following [PEP-0008](https://peps.python.org/pep-0008/#imports).
* All code has been formatted using [Black](https://black.readthedocs.io/en/stable/).
